### PR TITLE
Fix the organization creation docs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,6 +148,27 @@ components:
              type: array 
              items:
                type: string
+    CreateOrganizationInput:
+      type: object
+      properties:
+        name:
+          type: string
+        displayName:
+          type: string
+        url:
+          type: string
+        realm:
+          type: string
+        domains:
+          type: array
+          items:
+            type: string
+        attributes:
+          type: object
+          additionalProperties:
+             type: array 
+             items:
+               type: string
     OrganizationDomainRepresentation:
       type: object
       properties:
@@ -379,7 +400,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationRepresentation'
+              $ref: '#/components/schemas/CreateOrganizationInput'
         required: true
       responses:
         201:


### PR DESCRIPTION
Hey there,

A small fix for the OpenAPI definition, when the organization is created the `id` property is discarded from the input and a new one is generated [see here](https://github.com/p2-inc/keycloak-orgs/blob/df7c262aebc7f6c59b88cac7d06d70c9918076bd/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java#L34)

P.s.: Didn't wanted to change the `OrganizationRepresentation` as it's used in multiple places, but I hope the naming will be okay, let me know if you wanna have some different pattern for it.

Anyways, have a wonderful day!