### PR TITLE
Remove the `OrganizationDomainRepresentation::type` field as it's an unused field by all code.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -339,14 +339,11 @@ components:
           type: string
         record_value:
           type: string
-        type:
-          type: string
       required:
         - domain_name
         - verified
         - record_key
         - record_value
-        - type
     OrganizationRoleRepresentation:
       type: object
       properties:


### PR DESCRIPTION
Refs #305