### PR TITLE
Fix broken /docs/migration link in starter-tier blog post

### DIFF
--- a/blog/2026-06-30-starter-tier.md
+++ b/blog/2026-06-30-starter-tier.md
@@ -62,7 +62,7 @@ If you currently have active realms on our free, shared infrastructure:
 - **You have 30 days from today (2026-06-30) — through 2026-07-30 — to upgrade and migrate your realms** if you want to preserve them.
 - After 2026-07-30, the shared infrastructure will be shut down and its data permanently deleted.
 
-To migrate, create a Starter (or larger) cluster from the dashboard, export your realm config from the shared instance, and import it into your new cluster. Our [migration docs](/docs/migration) cover the steps; our team is happy to walk through it with you.
+To migrate, create a Starter (or larger) cluster from the dashboard, export your realm config from the shared instance, and import it into your new cluster. If you'd like a hand with the steps, our team is happy to walk through it with you.
 
 ## We're here to help
 


### PR DESCRIPTION
## Summary

Removes the broken `[migration docs](/docs/migration)` link in the starter-tier blog post. Docusaurus 3 fails the build on any broken link by design, so the deploy workflow on #338's merge ([run 28459661002](https://github.com/p2-inc/phasetwo-docs/actions/runs/28459661002)) errored:

```
- Broken link on source page path = /blog/starter-tier-launch/:
   -> linking to /docs/migration/
```

That blocks the entire site rebuild — not just the blog post not showing up; anything else merged to main since #338 is also stuck behind it.

## Why no replacement link

The closest existing doc is `/docs/user-migration/`, but that section is about importing users from external IdPs (Auth0, WorkOS, etc.) — not the right reference for the very different task of moving a realm off our shared infrastructure onto a Starter cluster. Rather than point people at a doc that doesn't cover the use case, the sentence is rephrased to lean on the "our team is happy to walk you through it" offer that was already in the paragraph.

## Test plan

- [ ] Workflow build passes on this PR (Docusaurus' broken-links check turns clean).
- [ ] After merge, /blog/starter-tier-launch/ appears on the live site.