### PR TITLE
Document password denylists and apply to realm

### DIFF
--- a/docs/getting-started/customizing-ui.md
+++ b/docs/getting-started/customizing-ui.md
@@ -151,9 +151,7 @@ Full customization details can be viewed in the Phase Two [Admin Portal Repo](ht
 
 ## Custom Themes
 
-If you decide to use a custom theme, you must contact Phase Two support to have it added to your Realm. It is only available to subscribes of dedicated clusters.
-
-Coming soon will be the ability to upload custom themes via the Phase Two dashboard.
+If you decide to use a custom theme, you can upload it yourself from the Phase Two Dashboard under `Cluster > Config > Resources`. See [Cluster Resources](/docs/self-service/resources) for the full walkthrough. Custom themes are available to subscribers of dedicated clusters.
 
 ### Keycloakify
 

--- a/docs/security/password-blacklist.md
+++ b/docs/security/password-blacklist.md
@@ -5,15 +5,28 @@ title: Password Blacklist
 
 Keycloak provides an easy method to add a password blacklist to your realm. This is useful for preventing users from choosing common or compromised passwords. If you don't have a password blacklist, you can use the one provided by [Have I Been Pwned](https://haveibeenpwned.com/Passwords).
 
-For subscribers of a dedicated cluster, contact support to enable to upload your list.
+On a dedicated cluster you can upload and apply your own list yourself — no support request needed. Denylists are available on every tier and are not subject to the theme and extension resource limits.
 
-Enabling the password blacklist is done in the Keycloak Admin Console:
+## Uploading and applying your list
+
+Upload the list as a **Password Denylist** cluster resource and apply it to a realm from the dashboard. See [Cluster Resources](/docs/self-service/resources) for the full walkthrough. In short:
+
+1. In `Cluster > Config > Resources`, click **Add New Resource** and create a resource of type **Password Denylist**.
+2. Upload your list as a `.txt` file with one password per line.
+3. Click **Refresh Cluster Resources** and wait for the cluster restart to complete.
+4. Expand the resource, click **Apply to Realm**, and apply it to the realms that should use it.
+
+Your list is deployed using the resource name plus a `.txt` extension, so a resource named `common-passwords` becomes `common-passwords.txt`. You can upload several lists and apply different ones to different realms.
+
+## Setting the policy manually
+
+You can also designate the file in the Keycloak Admin Console instead of using **Apply to Realm**:
 
 1. Log in to the Keycloak Admin Console via the Phase Two Dashboard.
 2. Visit the realm you want to configure. Open the console link for the specific realm.
 3. Navigate to the **Authentication** section in the left sidebar.
 4. Click on the **Policies** tab and in the dropdown select **Password Blacklist**.
-5. Provide the name of the file. Click "Save" to designate the file.
+5. Provide the name of the file — the resource name plus `.txt`, for example `common-passwords.txt`. Click "Save" to designate the file.
 
 <figure>
   <img src="/docs/security/password-policy.png" className="max-w-xl"  alt="Phase Two Team Details View" />

--- a/docs/self-service/resources.md
+++ b/docs/self-service/resources.md
@@ -7,19 +7,21 @@ Resources can be uploaded to your cluster for deployment to any Realm (deploymen
 
 - **Theme** — a Keycloak theme for login, account, or email UI customization. Uploaded per Keycloak major version.
 - **Extension** — a Keycloak server extension JAR (providers and SPI code). Uploaded per Keycloak major version.
-- **Password Denylist** — a Password Denylist file that is not tied to a Keycloak major version. It uses a single direct file upload and shares the extension resource limit.
+- **Password Denylist** — a list of passwords your users are not allowed to choose. It is not tied to a Keycloak major version and uses a single direct file upload. See [Password Blacklist](/docs/security/password-blacklist) for how denylists work in Keycloak.
 
 ### Resource limits by tier
 
 The resources available depend on your cluster tier:
 
-| Tier       | Themes    | Extensions / Password Denylists |
-| ---------- | --------- | ------------------------------- |
-| Starter    | 1         | Not available — themes only     |
-| Premium    | 1         | 1                               |
-| Enterprise | Unlimited | Unlimited                       |
+| Tier       | Themes    | Extensions                  | Password Denylists |
+| ---------- | --------- | --------------------------- | ------------------ |
+| Starter    | 1         | Not available — themes only | Unlimited          |
+| Premium    | 1         | 1                           | Unlimited          |
+| Enterprise | Unlimited | Unlimited                   | Unlimited          |
 
-Your current usage is shown next to the **Resources** heading (for example, `0/1 themes`). On the Starter tier, only themes usage is shown, since custom extensions are not supported.
+Password Denylists are not limited by tier. They are part of core Keycloak security rather than custom code, so you can upload as many as you need on any tier — including Starter, where custom extensions are not available.
+
+Your current usage is shown next to the **Resources** heading (for example, `0/1 themes`). Denylists are shown as a plain count, since they are uncapped.
 
 <img
 src="/docs/resources/resources-overview.png"
@@ -30,18 +32,20 @@ style={{ width: "100%", borderRadius: "8px" }}
 ### Adding a resource
 
 1.  Visit the `Cluster > Config > Resources` tab.
-2.  Click **Add New Resource**. Give the resource a recognizable name (lowercase letters, numbers, hyphens, or underscores), for example `theme-customer-1-0-0`, and choose the resource type — Theme, Extension, or Password Denylist.
+2.  Click **Add New Resource**. Give the resource a recognizable name (lowercase letters, numbers, and hyphens), for example `theme-customer-1-0-0`, and choose the resource type — Theme, Extension, or Password Denylist.
 
-    On **Starter** clusters, Theme is the only available type; the Extension and Password Denylist options are shown but disabled, with a note that Starter clusters do not allow custom extensions.
+    Any type you have run out of is shown but disabled, so you can always see what a higher tier offers. On **Starter** clusters the Extension option is disabled, with a note that Starter clusters do not allow custom extensions; Theme and Password Denylist remain available.
 
     :::note Screenshot needed
-    `resources-add-dialog.png` — the **Add a new cluster resource** dialog showing the Theme / Extension / Password Denylist type selection. Include a Starter-cluster variant showing the disabled Extension and Password Denylist options with the explanatory note.
+    `resources-add-dialog.png` — the **Add a new cluster resource** dialog showing the Theme / Extension / Password Denylist type selection with their icons. Include a Premium-cluster variant where the extension limit is used, showing the disabled Extension option alongside an available Password Denylist.
     :::
 
 3.  After the resource is created, upload the file.
 
     - **Themes and extensions** are uploaded per Keycloak major version. Activate a specific version (for example Keycloak 26 — only major versions are supported), click the upload icon, and select your file. The file must be a `.jar` file. Upload it for each Keycloak version you need it available on.
-    - **Password Denylists** use a single, cluster-wide upload and are not tied to a Keycloak major version.
+    - **Password Denylists** use a single, cluster-wide upload and are not tied to a Keycloak major version. The file must be a `.txt` file with one password per line.
+
+    A denylist is deployed to your cluster using the name of the resource plus a `.txt` extension. A resource named `common-passwords` becomes `common-passwords.txt`, and that is the exact file name a realm's password policy must reference. The optional label on an upload is for display only and does not change the deployed file name.
 
     <img
     src="/docs/resources/resources-upload.png"
@@ -61,7 +65,23 @@ alt="Resources Update Cluster"
 style={{ width: "60%", borderRadius: "8px" }}
 />
 
-Once the refresh is complete, visit your Realm (deployment) and select the theme for use. For an extension, configure it in your Realm according to how the extension operates.
+Once the refresh is complete, visit your Realm (deployment) and select the theme for use. For an extension, configure it in your Realm according to how the extension operates. For a Password Denylist, use **Apply to Realm** as described below.
+
+### Applying a Password Denylist to a realm
+
+Uploading a denylist makes the file available on the cluster; a realm only uses it once its password policy references it. You can do this from the dashboard rather than the Keycloak Admin Console.
+
+1.  Expand the denylist resource in the resources list and click **Apply to Realm**.
+2.  The dialog lists the realms on your cluster and shows which denylist each one currently uses, if any.
+3.  Click **Apply** on a realm to set this denylist as its password denylist, or **Remove** to clear it.
+
+Applying a denylist adds `passwordBlacklist(<resource-name>.txt)` to that realm's password policy and leaves every other policy item untouched. If the realm already used a different denylist, it is replaced.
+
+:::note
+Apply the denylist only after **Refresh Cluster Resources** and the resulting restart have completed. Keycloak validates that the file exists on the server when the policy is set, so applying it earlier fails.
+:::
+
+A denylist that is in use cannot be deleted or disabled — remove it from the realm first. This prevents a realm being left with a password policy pointing at a file that is no longer on the cluster.
 
 ### Finding and filtering resources
 


### PR DESCRIPTION
Follows the dashboard changes for [p2-inc/dashboard-v2#213.](https://github.com/p2-inc/dashboard-v2/pull/215)

## Why

Two pages were telling customers the wrong thing.

`security/password-blacklist.md` said "For subscribers of a dedicated cluster, contact support to enable to upload your list", which stopped being true when denylist uploads became self-service. It was quoted in the Slack thread behind #213 as a source of confusion for a customer who was trying to do it themselves.

`self-service/resources.md` documented denylists as sharing the extension resource limit and being unavailable on Starter. That is no longer how it works — denylists are uncapped on every tier.

## What changed

**`security/password-blacklist.md`** — replaced the contact-support line with the self-service flow: create a Password Denylist resource, upload a `.txt`, refresh cluster resources, then apply it to realms. The Keycloak Admin Console steps are kept as an alternative under their own heading, now stating that the file name to enter is the resource name plus `.txt`.

**`self-service/resources.md`** — split the tier table so denylists have their own column (unlimited everywhere), removed the "shares the extension resource limit" claim, and corrected the Starter guidance: only Extension is disabled there, not Password Denylist. Added a section on applying a denylist to a realm, documented that a resource named `common-passwords` deploys as `common-passwords.txt`, and noted that a denylist in use cannot be deleted or disabled until it is removed from the realm.

**`getting-started/customizing-ui.md`** — the Custom Themes section still said to contact support and that dashboard uploads were "coming soon", which contradicts the resources page. Now points at the self-service flow. This one is adjacent rather than strictly part of the denylist work; happy to split it out if you'd rather keep the PR tight.

Also corrected the resource-name rule from "lowercase letters, numbers, hyphens, or underscores" to "lowercase letters, numbers, and hyphens" — the backend regex rejects underscores.